### PR TITLE
Patch tuto et astuce

### DIFF
--- a/le-gameplay/tuto-et-astuce.md
+++ b/le-gameplay/tuto-et-astuce.md
@@ -22,7 +22,7 @@ Pense à bien allouer suffisamment de RAM pour pouvoir le télécharger !
 {% endhint %}
 
 
-### <mark style="color:green;">Enlever les barres violettes</mark>
+### <mark style="color:green;"> Enlever les barres violettes</mark>
 Si tu joues sur Lunar Client, Badlion, Feather ou autre sur un launcher autre que celui de base, il se peut que des **barres violettes** s'affichent sur ton écran lors de ta première connexion.  
 <figure><img src="../.gitbook/assets/Tuto_BarreViolette.png" alt=""></figure>
 

--- a/le-gameplay/tuto-et-astuce.md
+++ b/le-gameplay/tuto-et-astuce.md
@@ -5,18 +5,15 @@ description: Retrouvez ici différent tuto/astuce pour votre aventure sur évolu
 ### <mark style="color:green;">Mettre le texture pack</mark>
 Lors de votre première connexion, le serveur vous rajoute automatiquement le texture pack, si cela n'est pas le cas il vous suffit de suivre les étapes suivantes : 
 
-1.<span style="align-items: center;">
-Tu te rends dans le menu de sélection des serveurs, puis tu fais un **clic droit** sur Evolucraft. 
+1.<span style="align-items: center;"> Tu te rends dans le menu de sélection des serveurs, puis tu fais un **clic droit** sur Evolucraft. 
   <figure><img src="../.gitbook/assets/Tuto_EvoOverlay.png" alt="" width="600"></figure>
 </span>
 
-2.<span style="align-items: center;">
-En bas à gauche de ton écran, tu cliques sur le bouton **Modifier**.  
+2.<span style="align-items: center;"> En bas à gauche de ton écran, tu cliques sur le bouton **Modifier**.  
   <figure><img src="../.gitbook/assets/Tuto_Modifier.png" alt="" width="600"></figure>
 </span>
 
-3.<span style="align-items: center;">
-Tu actives les packs de ressources, puis tu cliques sur **Terminer**.
+3.<span style="align-items: center;"> Tu actives les packs de ressources, puis tu cliques sur **Terminer**.
   <figure><img src="../.gitbook/assets/Tuto_PackEnable.png" alt="" width="600"></figure>
 </span>
 
@@ -30,22 +27,18 @@ Si tu joues sur Lunar Client, Badlion, Feather ou autre sur un launcher autre qu
 <figure><img src="../.gitbook/assets/Tuto_BarreViolette.png" alt=""></figure>
 
 Pour les enlever sur **Lunar Client**, voici les étapes à suivre (la manipulation reste plus ou moins sur les autres launchers) :
-1.<span style="align-items: center;">
- Tu appuies sur Echap et tu vas dans les **paramètres** de ton launcher. 
+1.<span style="align-items: center;"> Tu appuies sur Echap et tu vas dans les **paramètres** de ton launcher. 
   <figure><img src="../.gitbook/assets/Tuto_LunarOption.png" alt="" width="600"></figure>
 </span>
 
-2.<span style="align-items: center;"> 
-  Tu recherches **Boss Bar** dans l’onglet de recherche.
+2.<span style="align-items: center;"> Tu recherches **Boss Bar** dans l’onglet de recherche.
   <figure><img src="../.gitbook/assets/Tuto_SelectBossBar.png" alt="" width="600"></figure>
 </span>
 
-3.<span style="align-items: center;">
-  Tu mets l'échelle à 1 (optionnel) et tu **désactives les barres personnalisées**.
+3.<span style="align-items: center;"> Tu mets l'échelle à 1 (optionnel) et tu **désactives les barres personnalisées**.
   <figure><img src="../.gitbook/assets/Tuto_ScaleEtDesac.png" alt="" width="600"></figure>
 </span>
 
-4.<span style="align-items: center;">
-Pour finir, tu vas dans la section permettant de modifier l’HUD et tu **centres** la Boss Bar.
+4.<span style="align-items: center;"> Pour finir, tu vas dans la section permettant de modifier l’HUD et tu **centres** la Boss Bar.
 <figure><img src="../.gitbook/assets/Tuto_BarrePlacement.png" alt="" width="600"></figure>
 </span>

--- a/le-gameplay/tuto-et-astuce.md
+++ b/le-gameplay/tuto-et-astuce.md
@@ -27,6 +27,7 @@ Si tu joues sur Lunar Client, Badlion, Feather ou autre sur un launcher autre qu
 <figure><img src="../.gitbook/assets/Tuto_BarreViolette.png" alt=""></figure>
 
 Pour les enlever sur **Lunar Client**, voici les étapes à suivre (la manipulation reste plus ou moins sur les autres launchers) :
+
 1.<span style="align-items: center;"> Tu appuies sur Echap et tu vas dans les **paramètres** de ton launcher. 
   <figure><img src="../.gitbook/assets/Tuto_LunarOption.png" alt="" width="600"></figure>
 </span>


### PR DESCRIPTION
Correction du tuto et des astuces : contrairement à GitHub, sur le wiki, le texte des listes était décalé de 1. Ce patch vise à corriger ce problème.