### PR TITLE
Création de la page "Coffre de vente" dans la catégorie Ville

### DIFF
--- a/le-gameplay/les shops de villes
+++ b/le-gameplay/les shops de villes
@@ -1,0 +1,38 @@
+# 🔖 Les Coffres de Vente
+
+**Les coffres de vente** servent **à vendre ou acheter des items** dans des contenants (coffre, double coffre, et coffre piégé) à des joueurs visitant votre 👁️‍🗨️ <a href="https://wiki.evolucraft.fr/les-villes/les-warps">**pwarp**</a>.
+
+## <mark style="color:green;">**🛒 Créer un Coffre de Vente dans votre Ville**</mark>
+
+* <mark style="color:green;">**Étape 1️⃣ :**</mark> Placez le coffre à l’endroit où vous souhaitez installer votre shop.
+
+* <mark style="color:green;">**Étape 2️⃣ :**</mark> Prenez en main l'item que vous souhaitez mettre en vente, puis cliquez avec le bouton gauche de votre souris sur le coffre.
+
+* <mark style="color:green;">**Étape 3️⃣ :**</mark> Insérez le prix unitaire auquel vous souhaitez que les autres joueurs achètent l’item.
+
+* <mark style="color:green;">**Étape BONUS :**</mark> Tapez `/qs buy` pour transformer votre coffre de vente en coffre d'achat.
+
+Et voilà ! Votre coffre de vente est créé 🤩 !
+
+{% hint style="info" %}
+**💡 REMARQUE : Pensez à créer votre pwarp au plus proche de vos coffres de vente afin d'éviter que les autres joueurs soient téléportés à plusieurs blocs de votre ville ou qu'ils ne puissent pas y accéder !**
+{% endhint %}
+
+## <mark style="color:green;">**🏪 Le Finditem**</mark>
+
+Le Finditem vous permet de **chercher un item** parmi **tous les coffres de vente existants**, et vous téléportera au **pwarp le plus proche du coffre de vente**. Lors de l'affichage de sa recherche, il indiquera dans un **ordre croissant les prix unitaires** de chaque shop.
+
+Pour cela, réalisez la commande suivante en fonction de votre besoin :
+* **<mark style="color:green;">`/finditem acheter <id de l'item>`</mark> : Permet de chercher tous les coffres où les joueurs vendent l'item.**
+* **<mark style="color:green;">`/finditem vendre <id de l'item>`</mark> : Permet de chercher tous les coffres où les joueurs achètent l'item.**
+
+## <mark style="color:green;">**💡 Quelques commandes à connaître !**</mark>
+
+* **<mark style="color:green;">`/qs price <montant>`</mark> : Permet de modifier le prix de votre coffre de vente.**
+* **<mark style="color:green;">`/qs buy`</mark> : Permet de transformer un coffre de vente en un coffre d'achat.**
+* **<mark style="color:green;">`/qs sell`</mark> : Permet de transformer un coffre d'achat en un coffre de vente.**
+* **<mark style="color:green;">`/qs item`</mark> : Permet de changer l'item en vente.**
+* **<mark style="color:green;">`/qs staff add <pseudo>`</mark> : Permet d'ajouter un membre.**
+* **<mark style="color:green;">`/qs toggledisplay`</mark> : Permet d'afficher ou de masquer l'item au-dessus du coffre.**
+
+Et voilà, vous savez tout pour créer votre magnifique shop ! ✨


### PR DESCRIPTION
# Les Coffres de Vente

Les coffres de vente servent à vendre ou acheter des items dans des contenants (coffres simples, doubles, ou piégés) à des joueurs visitant votre pwarp.  

## Créer un Coffre de Vente dans votre Ville

1. Placez le coffre à l’endroit où vous souhaitez installer votre shop.
2. Prenez en main l'item que vous souhaitez mettre en vente, puis cliquez avec le bouton gauche de votre souris sur le coffre.
3. Insérez le prix unitaire auquel vous souhaitez que les autres joueurs achètent l’item.
4. (Optionnel) Tapez `/qs buy` pour transformer votre coffre de vente en coffre d'achat.

Votre coffre de vente est maintenant créé !

**Remarque** : Pensez à créer votre pwarp au plus proche de vos coffres de vente pour éviter que les autres joueurs soient téléportés à plusieurs blocs de votre ville ou qu'ils ne puissent pas y accéder.

---

## Le Finditem

Le Finditem permet de chercher un item parmi tous les coffres de vente existants. Il vous téléporte au pwarp le plus proche du coffre correspondant et affiche les résultats triés par prix unitaire croissant.

Commandes :
- `/finditem acheter <id de l'item>` : Trouve tous les coffres où les joueurs vendent l'item.
- `/finditem vendre <id de l'item>` : Trouve tous les coffres où les joueurs achètent l'item.

---

## Commandes Utiles

- `/qs price <montant>` : Modifier le prix d’un coffre de vente.
- `/qs buy` : Transformer un coffre de vente en coffre d'achat.
- `/qs sell` : Transformer un coffre d'achat en coffre de vente.
- `/qs item` : Changer l’item en vente.
- `/qs staff add <pseudo>` : Ajouter un membre.
- `/qs toggledisplay` : Afficher ou masquer l’item au-dessus du coffre.